### PR TITLE
parameterise port to support minikube

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ADD springboot-realm.json /opt/jboss/keycloak/
 
 ENTRYPOINT [ "/opt/jboss/docker-entrypoint.sh" ]
 
-EXPOSE 8180
+ENV PORT_OFFSET 100
 
-CMD ["-b", "0.0.0.0", "-Dkeycloak.import=/opt/jboss/keycloak/springboot-realm.json -Djboss.socket.binding.port-offset=100"]
+EXPOSE 8180 30081
+
+CMD ["-b", "0.0.0.0", "-Dkeycloak.import=/opt/jboss/keycloak/springboot-realm.json -Djboss.socket.binding.port-offset=${env.PORT_OFFSET}"]


### PR DESCRIPTION
This way by default will start on 8180. Or you can run on 30081 by doing:

docker run -e PORT_OFFSET=22001 -p 30081:30081 activiti/activiti-cloud-sso-idm

Not a perfect mechanism but should do the job of supporting what we want with minikube.